### PR TITLE
fix: Error middleware should have 4 args

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -12,7 +12,7 @@ require('./config/middlewares')(app);
 app.use('/api', api);
 app.use('/auth', auth);
 
-app.use((err, req, res/*, next*/) => {
+app.use((err, req, res, next) => {
   res.status(err.status || 500);
   res.json({ error : err });
 });


### PR DESCRIPTION
Express knows that functions in routes have differing numbers of
args, most usually (req, res) (which has a function length of 2).
In the case of regular middleware such as (req, res) or
(req, res, next) having function lengths of 2 and 3, they are
treated as regular middleware.

With error middleware - to differentiate between regular and error
middleware - they need to have a function length of 4, which is the
standard (err, req, res, next). Hence why this fails since
(err, req, res) is being treated as (req, res, next) since it has
length of three and therefore fails with:

TypeError: res.status is not a function
    at app.use (/home/chilts/src/ezy/seedpress-cms/server/server.js:16:7)